### PR TITLE
Feat: API 응답을 위한 CommonResponse 추가

### DIFF
--- a/src/main/java/kr/co/tastyle/tastyle/common/response/CommonResponse.java
+++ b/src/main/java/kr/co/tastyle/tastyle/common/response/CommonResponse.java
@@ -2,26 +2,29 @@ package kr.co.tastyle.tastyle.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import static kr.co.tastyle.tastyle.common.response.ResponseCode.SUCCESS;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class CommonResponse<T> {
-    private int status;
+    private int code;
     private String message;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T result;
 
     public CommonResponse(T result) {
-        this.status = SUCCESS.getHttpStatus().value();
+        this.code = SUCCESS.getCode();
         this.message = SUCCESS.getMessage();
         this.result = result;
     }
 
-    public CommonResponse(ResponseCode status) {
-        this.status = SUCCESS.getHttpStatus().value();
+    public CommonResponse(ResponseCode status, T result) {
+        this.code = status.getCode();
         this.message = status.getMessage();
+        this.result = result;
     }
 }

--- a/src/main/java/kr/co/tastyle/tastyle/common/response/ResponseCode.java
+++ b/src/main/java/kr/co/tastyle/tastyle/common/response/ResponseCode.java
@@ -1,18 +1,16 @@
 package kr.co.tastyle.tastyle.common.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@AllArgsConstructor
 public enum ResponseCode {
-    SUCCESS(HttpStatus.OK, "요청에 성공하였습니다.")
+    SUCCESS(1000, "요청에 성공하였습니다."),
+    CREATED(1001,"생성에 성공하였습니다."),
     ;
 
-    private HttpStatus httpStatus;
+    private int code;
     private String message;
-
-    ResponseCode(HttpStatus httpStatus, String message) {
-        this.httpStatus = httpStatus;
-        this.message = message;
-    }
 }


### PR DESCRIPTION
1. 로그인과 회원가입을 구분하기 위해 ResponseCode에 CREATED를 추가하였다.
2. CREATED의 코드값을 보여주기 위해 CommonResponse 생성자를 추가하였다.